### PR TITLE
Allow customizable path and filename for .htmlhintrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You can configure linter-htmlhint by editing ~/.atom/config.cson (choose Open Yo
 ```
 'linter-htmlhint':
   'htmlhintExecutablePath': null #htmlhint path. run 'which htmlhint' to find the path
+  'htmlHintRcFilePath': #OPTIONAL custom path to the htmlhintrc file (which can be used to customize rulesets that are run against the HTML)
+  'htmlHintRcFileName': #OPTIONAL filename of the htmlhintrc file (defaults to '.htmlhintrc', but can be overridden)
 ```
 
 ## Contributing

--- a/lib/linter-htmlhint.coffee
+++ b/lib/linter-htmlhint.coffee
@@ -19,14 +19,22 @@ class LinterHtmlhint extends Linter
 
   isNodeExecutable: yes
 
-  constructor: (editor) ->
-    super(editor)
-
-    config = findFile @cwd, ['.htmlhintrc']
+  # update the ruleset anytime the watched htmlhintrc file changes
+  setupHtmlHintRc: =>
+    htmlHintRcPath = atom.config.get 'linter.linter-htmlhint.htmlhintRcFilePath'
+    fileName = atom.config.get('linter.linter-htmlhint.htmlhintRcFileName') || '.htmlhintrc'
+    config = findFile htmlHintRcPath, [fileName]
     if config
       @cmd = @cmd.concat ['-c', config]
 
+
+  constructor: (editor) ->
+    super(editor)
     atom.config.observe 'linter-htmlhint.htmlhintExecutablePath', @formatShellCmd
+
+    # reload if path or file name changed of the htmlhintrc file
+    atom.config.observe 'linter-htmlhint.htmlHintRcFilePath', @setupHtmlHintRc
+    atom.config.observe 'linter-htmlhint.htmlHintRcFileName', @setupHtmlHintRc
 
   formatShellCmd: =>
     htmlhintExecutablePath = atom.config.get 'linter-htmlhint.htmlhintExecutablePath'


### PR DESCRIPTION
This commit allows a user to specify a custom file path and file name
for a .htmlhintrc file. This is useful in cases where someone wants to
  keep a versioned dotfiles repository, but does not want to worry about
  symlinks on a machine. The syntax in the config.cson file of atom is:

  linter:
    "linter-htmlhint":
       htmlhintRcFilePath: "/Users/jacobsmith/"
       htmlhintRcFileName: ".htmlhintrc.custom"

Obviously, these paths and filenames can be any valid path and
configuration file for htmlhint. Please note that the htmlhintrc
fileName defaults to '.htmlhintrc' so it does not need overridden if
that name is not changing. Zero, one, or both of the options can be set.

Also, just for clarification's sake, the
.htmlhintrc file is the configuration file of the actual binary htmlhint
(https://github.com/yaniswang/HTMLHint), not linter-htmllint.