### PR TITLE
Revert "Allow customizable path and filename for .htmlhintrc"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ You can configure linter-htmlhint by editing ~/.atom/config.cson (choose Open Yo
 ```
 'linter-htmlhint':
   'htmlhintExecutablePath': null #htmlhint path. run 'which htmlhint' to find the path
-  'htmlHintRcFilePath': #OPTIONAL custom path to the htmlhintrc file (which can be used to customize rulesets that are run against the HTML)
-  'htmlHintRcFileName': #OPTIONAL filename of the htmlhintrc file (defaults to '.htmlhintrc', but can be overridden)
 ```
 
 ## Contributing

--- a/lib/linter-htmlhint.coffee
+++ b/lib/linter-htmlhint.coffee
@@ -19,22 +19,14 @@ class LinterHtmlhint extends Linter
 
   isNodeExecutable: yes
 
-  # update the ruleset anytime the watched htmlhintrc file changes
-  setupHtmlHintRc: =>
-    htmlHintRcPath = atom.config.get 'linter.linter-htmlhint.htmlhintRcFilePath'
-    fileName = atom.config.get('linter.linter-htmlhint.htmlhintRcFileName') || '.htmlhintrc'
-    config = findFile htmlHintRcPath, [fileName]
+  constructor: (editor) ->
+    super(editor)
+
+    config = findFile @cwd, ['.htmlhintrc']
     if config
       @cmd = @cmd.concat ['-c', config]
 
-
-  constructor: (editor) ->
-    super(editor)
     atom.config.observe 'linter-htmlhint.htmlhintExecutablePath', @formatShellCmd
-
-    # reload if path or file name changed of the htmlhintrc file
-    atom.config.observe 'linter-htmlhint.htmlHintRcFilePath', @setupHtmlHintRc
-    atom.config.observe 'linter-htmlhint.htmlHintRcFileName', @setupHtmlHintRc
 
   formatShellCmd: =>
     htmlhintExecutablePath = atom.config.get 'linter-htmlhint.htmlhintExecutablePath'


### PR DESCRIPTION
Reverts AtomLinter/linter-htmlhint#6