### PR TITLE
closes #9 cannot read property split of `undefined`

### DIFF
--- a/lib/linter-htmlhint.coffee
+++ b/lib/linter-htmlhint.coffee
@@ -21,7 +21,7 @@ class LinterHtmlhint extends Linter
 
   # update the ruleset anytime the watched htmlhintrc file changes
   setupHtmlHintRc: =>
-    htmlHintRcPath = atom.config.get 'linter.linter-htmlhint.htmlhintRcFilePath'
+    htmlHintRcPath = atom.config.get('linter.linter-htmlhint.htmlhintRcFilePath') || ''
     fileName = atom.config.get('linter.linter-htmlhint.htmlhintRcFileName') || '.htmlhintrc'
     config = findFile htmlHintRcPath, [fileName]
     if config

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "linter-package": true,
   "activationEvents": [],
   "main": "./lib/init",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Linter plugin for HTML, using htmlhint",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://github.com/AtomLinter/linter-htmlhint/issues/9#issuecomment-86758097 for analysis