### PR TITLE
Changed empty string default path to `@cwd`.  While the empty path fixed...

### DIFF
--- a/lib/linter-htmlhint.coffee
+++ b/lib/linter-htmlhint.coffee
@@ -21,7 +21,7 @@ class LinterHtmlhint extends Linter
 
   # update the ruleset anytime the watched htmlhintrc file changes
   setupHtmlHintRc: =>
-    htmlHintRcPath = atom.config.get('linter.linter-htmlhint.htmlhintRcFilePath') || ''
+    htmlHintRcPath = atom.config.get('linter.linter-htmlhint.htmlhintRcFilePath') || @cwd
     fileName = atom.config.get('linter.linter-htmlhint.htmlhintRcFileName') || '.htmlhintrc'
     config = findFile htmlHintRcPath, [fileName]
     if config


### PR DESCRIPTION
... the crash, the `.htmlhintrc` file was not being loaded properly if it existed.