### PR TITLE
This should fix #12/#16 and #13, i. e. "Package.activateConfig is deprec...

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,8 +1,11 @@
 path = require 'path'
 
 module.exports =
-  configDefaults:
-    htmlhintExecutablePath: path.join __dirname, '..', 'node_modules', 'htmlhint', 'bin'
+  config:
+    htmlhintExecutablePath:
+      default: path.join __dirname, '..', 'node_modules', 'htmlhint', 'bin'
+      title: 'HTMLHint Executable Path'
+      type: 'string'
 
   activate: ->
     console.log 'activate linter-htmlhint'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-htmlhint",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": {},
   "main": "./lib/init",
   "version": "0.0.13",
   "description": "Linter plugin for HTML, using htmlhint",


### PR DESCRIPTION
...ated" and "Package.getActivationCommands is deprecated".

I used and adjusted the changes from https://github.com/AtomLinter/linter-csslint, so it should work without a problem (I didn't encounter any problems yet).