### PR TITLE
Get json instead of text from htmlhint

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -16,7 +16,7 @@ module.exports =
       @subscriptions.add atom.config.observe 'linter-htmlhint.executablePath',
         (executablePath) =>
           @executablePath = executablePath
-      @scopes =  ['text.html.angular', 'text.html.basic', 'text.html.erb', 'text.html.gohtml', 'text.html.jsp', 'text.html.mustache', 'text.html.handlebars', 'text.html.php', 'text.html.ruby']
+      @scopes =  ['text.html.angular', 'text.html.basic', 'text.html.erb', 'text.html.gohtml', 'text.html.jsp', 'text.html.mustache', 'text.html.php', 'text.html.ruby']
 
   deactivate: ->
     @subscriptions.dispose()
@@ -31,32 +31,17 @@ module.exports =
         filePath = textEditor.getPath()
         htmlhintrc = helpers.findFile(filePath, '.htmlhintrc')
         text = textEditor.getText()
-        parameters = [ filePath ]
+        parameters = [filePath,'--format','json']
 
         if htmlhintrc and '-c' not in parameters
           parameters = parameters.concat ['-c', htmlhintrc]
 
         return helpers.execNode(atom.config.get('linter-htmlhint.executablePath'), parameters, {}).then (output) ->
-          # console.log('output', output)
-          parsed = helpers.parse(output, 'line (?<line>[0-9]+), col (?<col>[0-9]+): (?<message>.+)')
-
-          parsed.map (match) ->
-
-            # use the formatting code in the message to determin type.
-            if match.text[1..4] == "[33m"
-              match.type = 'warning'
-            else if match.text[1..4] == "[31m"
-              match.type = 'error'
-            else
-              match.type = 'info'
-
-            # remove the formatting codes:
-            match.text = match.text[5...-5]
-
-            # add filepath to return object
-            match.filePath = filePath
-
-            # console.log 'match', match
-            return match
-
-          return parsed
+          linterResults = JSON.parse output
+          return [] unless linterResults.length
+          linterMessages = linterResults[0].messages
+          return linterMessages.map (msg) ->
+            range : [[msg.line-1, msg.col-1], [msg.line-1, msg.col-1]]
+            type : msg.type
+            text : msg.message
+            filePath : filePath


### PR DESCRIPTION
linter-htmlhint doesn't work anymore as yaniswang/HTMLHint has changed its default text output

For example 
  output before:
    line 2, col 1: Special characters must be escaped : [ < ].
  output now:
          L2 |<lang="en">
                ^ Special characters must be escaped : [ < ]. (spec-char-escape)

This branch uses the Json output that yaniswang/HTMLHint offers and so avoids the more costly regex parsing.