### PR TITLE
Speed up and fix parsing errors 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "atom-linter": "~3.3.0",
-    "htmlhint": "~0.9.12"
+    "htmlhint": "admosity/HTMLhint#mini-format"
   }
 }


### PR DESCRIPTION
- custom htmlhint with new line json object stream format that is compliant with atom-linter fields
- consume data faster by interfacing directly with BufferedNodeProcess
- attempt to kill htmlhint process if pane is destroyed

Don't know if I'm committing blasphemy, but I'm loading up a slightly custom version of htmlhint that spits out atom-linter compliant objects and has fixes for #50 and #45. I might be doing something wrong with killing the last running htmlhint process.