### PR TITLE
Remove Handlebars support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ const GRAMMAR_SCOPES = [
   'text.html.gohtml',
   'text.html.jsp',
   'text.html.mustache',
-  'text.html.handlebars',
   'text.html.ruby'
 ];
 


### PR DESCRIPTION
There is a [dedicated linter](https://atom.io/packages/linter-handlebars) for Handlebars, removing this as it isn't fully supported in the first place.

Any reason not to merge this @johnwebbcole?

Fixes #47.