### PR TITLE
Make scopes configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 # Project specific config
-os:
-  - linux
-  - osx
-
-env:
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
 
 # Installed for linting the project
 language: node_js
-node_js: "6"
+
+matrix:
+  include:
+    - os: linux
+      env: ATOM_CHANNEL=stable
+      node_js: "6"
+
+    - os: linux
+      env: ATOM_CHANNEL=beta
+      node_js: "6"
+
+    - os: osx
+      env: ATOM_CHANNEL=stable
+      node_js: "6"
 
 # Generic setup follows
 script: 'curl -Ls https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.sh | sh'

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,19 @@
 'use babel';
 
-const GRAMMAR_SCOPES = [
-  'text.html.angular',
-  'text.html.basic',
-  'text.html.erb',
-  'text.html.gohtml',
-  'text.html.jsp',
-  'text.html.mustache',
-  'text.html.ruby'
-];
+import { CompositeDisposable } from 'atom';
+
+const grammarScopes = [];
 
 export function activate() {
   require('atom-package-deps').install('linter-htmlhint');
+
+  const subscriptions = new CompositeDisposable();
+  subscriptions.add(atom.config.observe('linter-htmlhint.enabledScopes', scopes => {
+    // Remove any old scopes
+    grammarScopes.splice(0, grammarScopes.length);
+    // Add the current scopes
+    Array.prototype.push.apply(grammarScopes, scopes);
+  }));
 }
 
 function getConfig(filePath) {
@@ -38,7 +40,7 @@ function getConfig(filePath) {
 export function provideLinter() {
   return {
     name: 'htmlhint',
-    grammarScopes: GRAMMAR_SCOPES,
+    grammarScopes,
     scope: 'file',
     lintOnFly: true,
     lint: editor => {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,25 @@
     "url": "https://github.com/AtomLinter/linter-htmlhint.git"
   },
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.4.0 <2.0.0"
+  },
+  "configSchema": {
+    "enabledScopes": {
+      "description": "List of scopes to run HTMLHint on, run `Editor: Log Cursor Scope` to determine the scopes for a file.",
+      "type": "array",
+      "default": [
+        "text.html.angular",
+        "text.html.basic",
+        "text.html.erb",
+        "text.html.gohtml",
+        "text.html.jsp",
+        "text.html.mustache",
+        "text.html.ruby"
+      ],
+      "items": {
+        "type": "string"
+      }
+    }
   },
   "scripts": {
     "test": "apm test",
@@ -40,18 +58,19 @@
   "eslintConfig": {
     "rules": {
       "comma-dangle": [
-        2,
+        "error",
         "never"
       ],
-      "global-require": 0,
+      "global-require": "off",
       "import/no-unresolved": [
-        2,
+        "error",
         {
           "ignore": [
             "atom"
           ]
         }
-      ]
+      ],
+      "import/no-extraneous-dependencies": "off"
     },
     "extends": "airbnb-base",
     "globals": {


### PR DESCRIPTION
Change the allowed scopes to a configurable setting, allowing any scope to be added that the user wants.

Note that [many](https://github.com/AtomLinter/linter-htmlhint/pull/52#issuecomment-157447911) of the default scopes should be removed as HTMLHint doesn't properly support them, but I left them in as that is what is currently released.

Fixes #82.
Fixes #124.