### PR TITLE
Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Project specific config
+### Project specific config ###
 
 # Installed for linting the project
 language: node_js
@@ -17,8 +17,15 @@ matrix:
       env: ATOM_CHANNEL=stable
       node_js: "6"
 
-# Generic setup follows
-script: 'curl -Ls https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.sh | sh'
+env:
+  global:
+    - ATOM_LINT_WITH_BUNDLED_NODE="false"
+
+### Generic setup follows ###
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+# Needed to disable the auto-install step running `npm install`
+install: true
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
-# Project specific config
+### Project specific config ###
 environment:
+  ATOM_LINT_WITH_BUNDLED_NODE: "false"
+
   matrix:
   - ATOM_CHANNEL: stable
   - ATOM_CHANNEL: beta
@@ -8,9 +10,9 @@ install:
   # Install Node.js to run any configured linters
   - ps: Install-Product node 6
 
-# Generic setup follows
+### Generic setup follows ###
 build_script:
-  - ps: iex ((new-object net.webclient).DownloadString('https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.ps1'))
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
 
 branches:
   only:

--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,13 @@
-dependencies:
-  override:
-    - curl -L https://atom.io/download/deb -o atom-amd64.deb
-    - sudo dpkg --install atom-amd64.deb || true
-    - sudo apt-get update
-    - sudo apt-get -f install
-    - npm install
-
 test:
   override:
-    - npm run lint
-    # Remove the node_modules installed with the system npm to test real apm install
-    - rm -Rf node_modules
-    - atom -v
-    - apm -v
-    - apm install --production
-    - apm test
+    - curl -s https://raw.githubusercontent.com/Arcanemagus/ci/atomlinter/build-package.sh | sh
+
+dependencies:
+  override:
+    - echo "Managed in the script"
 
 machine:
   node:
     version: 6
+  environment:
+    ATOM_LINT_WITH_BUNDLED_NODE: "false"


### PR DESCRIPTION
* Move Travis-CI and AppVeyor back to the official repository
* Send the new flag to use the system Node.js on Travis-CI and AppVeyor
* Update CircleCI to use the same script as Travis-CI