### PR TITLE
Don't lint html.erb and html.ruby scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "text.html.basic",
         "text.html.gohtml",
         "text.html.jsp",
-        "text.html.mustache",
+        "text.html.mustache"
       ],
       "items": {
         "type": "string"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
       "default": [
         "text.html.angular",
         "text.html.basic",
-        "text.html.erb",
         "text.html.gohtml",
         "text.html.jsp",
         "text.html.mustache",
-        "text.html.ruby"
       ],
       "items": {
         "type": "string"


### PR DESCRIPTION
This linter doesn't handle ERB and Ruby, but it pretends to which causes a lot of false errors on ERB templates to the point where it's nearly impossible to edit any ERB file with htmlhint enabled.

Additionally there is a proper ERB linter available in the [linter-erb](https://github.com/AtomLinter/linter-erb) package.

For reference:

- AtomLinter/linter-erb#94
- #44 
- https://github.com/AtomLinter/linter-htmlhint/issues/50#issuecomment-157164114
- https://github.com/AtomLinter/linter-htmlhint/issues/72#issuecomment-184010579
- https://github.com/AtomLinter/linter-htmlhint/issues/73#issuecomment-186412536