### PR TITLE
Add experimental PHP support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,16 +98,16 @@ export default {
           return null;
         }
 
-        const removePHP = function (str) {
-            return str.replace(/<\?php(?:[\s\S])+?\?>/gi, function (match) {
-                const newlineCount = (match.match(/\r?\n|\r/g) || []).length;
-                let newlines = '';
-                for (let i = 0; i < newlineCount; i++) {
-                    newlines += '\n';
-                }
-                return newlines;
-            });
-        }
+        const removePHP = (str) => {
+          return str.replace(/<\?php(?:[\s\S])+?\?>/gi, (match) => {
+            const newlineCount = (match.match(/\r?\n|\r/g) || []).length;
+            let newlines = '';
+            for (let i = 0; i < newlineCount; i += 1) {
+              newlines += '\n';
+            }
+            return newlines;
+          });
+        };
 
         const fileText = removePHP(editor.getText());
         if (!fileText) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,17 +98,16 @@ export default {
           return null;
         }
 
-        const removePHP = str => str.replace(/<\?php(?:[\s\S])+?\?>/gi, (match) => {
-          const newlineCount = (match.match(/\r?\n|\r/g) || []).length;
-          let newlines = '';
-          for (let i = 0; i < newlineCount; i += 1) {
-            newlines += '\n';
-          }
-          return newlines;
+        const removePHP = str => str.replace(/<\?(?:php)?(?:[\s\S])+?\?>/gi, (match) => {
+          const newlines = match.match(/\r?\n|\r/g);
+          const newlineCount = newlines ? newlines.length : 0;
+          
+          return '\n'.repeat(newlineCount);
         });
 
-        const fileText = removePHP(editor.getText());
-        if (!fileText) {
+        const fileText = editor.getText();
+        const fileTextStripped = removePHP(fileText);
+        if (!fileTextStripped) {
           return [];
         }
 
@@ -117,9 +116,9 @@ export default {
 
         const ruleset = await getConfig(filePath);
 
-        const messages = HTMLHint.verify(fileText, ruleset || undefined);
+        const messages = HTMLHint.verify(fileTextStripped, ruleset || undefined);
 
-        if (removePHP(editor.getText()) !== fileText) {
+        if (editor.getText() !== fileText) {
           // Editor contents have changed, tell Linter not to update
           return null;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ export default {
           return null;
         }
 
-        const removePHP = str => str.replace(/<\?(?:php)?(?:[\s\S])+?\?>/gi, (match) => {
+        const removePHP = str => str.replace(/<\?(?:php|=)?(?:[\s\S])+?\?>/gi, (match) => {
           const newlines = match.match(/\r?\n|\r/g);
           const newlineCount = newlines ? newlines.length : 0;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ export default {
         const removePHP = str => str.replace(/<\?(?:php)?(?:[\s\S])+?\?>/gi, (match) => {
           const newlines = match.match(/\r?\n|\r/g);
           const newlineCount = newlines ? newlines.length : 0;
-          
+
           return '\n'.repeat(newlineCount);
         });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,18 @@ export default {
           return null;
         }
 
-        const fileText = editor.getText();
+        const removePHP = function (str) {
+            return str.replace(/<\?php(?:[\s\S])+?\?>/gi, function (match) {
+                const newlineCount = (match.match(/\r?\n|\r/g) || []).length;
+                let newlines = '';
+                for (let i = 0; i < newlineCount; i++) {
+                    newlines += '\n';
+                }
+                return newlines;
+            });
+        }
+
+        const fileText = removePHP(editor.getText());
         if (!fileText) {
           return [];
         }
@@ -110,7 +121,7 @@ export default {
 
         const messages = HTMLHint.verify(fileText, ruleset || undefined);
 
-        if (editor.getText() !== fileText) {
+        if (removePHP(editor.getText()) !== fileText) {
           // Editor contents have changed, tell Linter not to update
           return null;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,16 +98,14 @@ export default {
           return null;
         }
 
-        const removePHP = (str) => {
-          return str.replace(/<\?php(?:[\s\S])+?\?>/gi, (match) => {
-            const newlineCount = (match.match(/\r?\n|\r/g) || []).length;
-            let newlines = '';
-            for (let i = 0; i < newlineCount; i += 1) {
-              newlines += '\n';
-            }
-            return newlines;
-          });
-        };
+        const removePHP = str => str.replace(/<\?php(?:[\s\S])+?\?>/gi, (match) => {
+          const newlineCount = (match.match(/\r?\n|\r/g) || []).length;
+          let newlines = '';
+          for (let i = 0; i < newlineCount; i += 1) {
+            newlines += '\n';
+          }
+          return newlines;
+        });
 
         const fileText = removePHP(editor.getText());
         if (!fileText) {


### PR DESCRIPTION
Adds PHP support by running a RegEx replace on file contents before linting.

It allows HTMLHint to run on PHP documents with HTML in without lots of false errors showing for PHP code.

**`/<\?php(?:[\s\S])+?\?>/gi`**
This regex is used to strip anything inside a PHP tag and the PHP tag itself. The match is then checked to see how many newlines are used, _n_, (using `/\r?\n|\r/g`), and then _n_ newlines are inserted into the text, so that Linter errors still show at the correct lines in documents.

Users will have to add `text.html.php` to the enabled scopes for the package to run at all.