### PR TITLE
Option to disable when no .htmlhintrc file is found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,13 @@ let generateRange;
 let tinyPromisify;
 let stripJSONComments;
 
+// Configuration
+let disableWhenNoHtmlhintConfig;
+
+// Internal variables
 const phpEmbeddedScope = 'text.html.php';
 
+// Internal functions
 const getConfig = async (filePath) => {
   const readFile = tinyPromisify(fsReadFile);
   const configPath = await findAsync(dirname(filePath), '.htmlhintrc');
@@ -86,6 +91,9 @@ export default {
       // Add the current scopes
       Array.prototype.push.apply(this.grammarScopes, scopes);
     }));
+    this.subscriptions.add(atom.config.observe('linter-htmlhint.disableWhenNoHtmhintConfig', (value) => {
+      disableWhenNoHtmlhintConfig = value;
+    }));
   },
 
   deactivate() {
@@ -123,6 +131,9 @@ export default {
         loadDeps();
 
         const ruleset = await getConfig(filePath);
+        if (!ruleset && disableWhenNoHtmlhintConfig) {
+          return null;
+        }
 
         const messages = HTMLHint.verify(text, ruleset || undefined);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ export default {
       // Add the current scopes
       Array.prototype.push.apply(this.grammarScopes, scopes);
     }));
-    this.subscriptions.add(atom.config.observe('linter-htmlhint.disableWhenNoHtmhintConfig', (value) => {
+    this.subscriptions.add(atom.config.observe('linter-htmlhint.disableWhenNoHtmlhintConfig', (value) => {
       disableWhenNoHtmlhintConfig = value;
     }));
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "disableWhenNoHtmhintConfig": {
+      "title": "Disable when no HTMLHint config is found",
+      "type": "boolean",
+      "default": true
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "type": "string"
       }
     },
-    "disableWhenNoHtmhintConfig": {
+    "disableWhenNoHtmlhintConfig": {
       "title": "Disable when no HTMLHint config is found",
       "type": "boolean",
       "default": true

--- a/spec/linter-htmlhint-spec.js
+++ b/spec/linter-htmlhint-spec.js
@@ -32,4 +32,26 @@ describe('The htmlhint provider for Linter', () => {
 
     expect(messages.length).toBe(0);
   });
+
+  it('lints an invalid file (bad.html) with a default configuration when no config file is present', async () => {
+    atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', false);
+
+    const bad = path.join(__dirname, 'fixtures', 'bad.html');
+    const editor = await atom.workspace.open(bad);
+    spyOn(editor, 'getPath').andReturn(__dirname);
+    const messages = await lint(editor);
+
+    expect(messages.length).toEqual(3);
+  });
+
+  it('does not lint an invalid file (bad.html) when no config is found and the disable option set', async () => {
+    atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', true);
+
+    const bad = path.join(__dirname, 'fixtures', 'bad.html');
+    const editor = await atom.workspace.open(bad);
+    spyOn(editor, 'getPath').andReturn(__dirname);
+    const messages = await lint(editor);
+
+    expect(messages).toBe(null);
+  });
 });

--- a/spec/linter-htmlhint-spec.js
+++ b/spec/linter-htmlhint-spec.js
@@ -7,6 +7,9 @@ import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 const { lint } = require('../lib/index.js').provideLinter();
 
 describe('The htmlhint provider for Linter', () => {
+  const badFile = path.join(__dirname, 'fixtures', 'bad.html');
+  const goodFile = path.join(__dirname, 'fixtures', 'good.html');
+
   beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
     await atom.packages.activatePackage('linter-htmlhint');
@@ -14,44 +17,42 @@ describe('The htmlhint provider for Linter', () => {
   });
 
   it('detects invalid coding style in bad.html and report as error', async () => {
-    const bad = path.join(__dirname, 'fixtures', 'bad.html');
-    const editor = await atom.workspace.open(bad);
+    const editor = await atom.workspace.open(badFile);
     const messages = await lint(editor);
 
     expect(messages.length).toEqual(1);
     expect(messages[0].type).toBe('error');
     expect(messages[0].text).toBe('Doctype must be declared first.');
-    expect(messages[0].filePath).toBe(bad);
+    expect(messages[0].filePath).toBe(badFile);
     expect(messages[0].range).toEqual([[0, 0], [0, 5]]);
   });
 
   it('finds nothing wrong with a valid file (good.html)', async () => {
-    const good = path.join(__dirname, 'fixtures', 'good.html');
-    const editor = await atom.workspace.open(good);
+    const editor = await atom.workspace.open(goodFile);
     const messages = await lint(editor);
 
     expect(messages.length).toBe(0);
   });
 
-  it('lints an invalid file (bad.html) with a default configuration when no config file is present', async () => {
-    atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', false);
+  describe('The "Disable when no HTMLHint config is found" option', () => {
+    it('lints files with no config when disabled', async () => {
+      atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', false);
 
-    const bad = path.join(__dirname, 'fixtures', 'bad.html');
-    const editor = await atom.workspace.open(bad);
-    spyOn(editor, 'getPath').andReturn(__dirname);
-    const messages = await lint(editor);
+      const editor = await atom.workspace.open(badFile);
+      spyOn(editor, 'getPath').andReturn(__dirname);
+      const messages = await lint(editor);
 
-    expect(messages.length).toEqual(3);
-  });
+      expect(messages.length).toEqual(3);
+    });
 
-  it('does not lint an invalid file (bad.html) when no config is found and the disable option set', async () => {
-    atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', true);
+    it("doesn't lint files with no config when enabled", async () => {
+      atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', true);
 
-    const bad = path.join(__dirname, 'fixtures', 'bad.html');
-    const editor = await atom.workspace.open(bad);
-    spyOn(editor, 'getPath').andReturn(__dirname);
-    const messages = await lint(editor);
+      const editor = await atom.workspace.open(badFile);
+      spyOn(editor, 'getPath').andReturn(__dirname);
+      const messages = await lint(editor);
 
-    expect(messages).toBe(null);
+      expect(messages).toBe(null);
+    });
   });
 });

--- a/spec/linter-htmlhint-spec.js
+++ b/spec/linter-htmlhint-spec.js
@@ -36,7 +36,7 @@ describe('The htmlhint provider for Linter', () => {
 
   describe('The "Disable when no HTMLHint config is found" option', () => {
     it('lints files with no config when disabled', async () => {
-      atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', false);
+      atom.config.set('linter-htmlhint.disableWhenNoHtmlhintConfig', false);
 
       const editor = await atom.workspace.open(badFile);
       spyOn(editor, 'getPath').andReturn(__dirname);
@@ -46,7 +46,7 @@ describe('The htmlhint provider for Linter', () => {
     });
 
     it("doesn't lint files with no config when enabled", async () => {
-      atom.config.set('linter-htmlhint.disableWhenNoHtmhintConfig', true);
+      atom.config.set('linter-htmlhint.disableWhenNoHtmlhintConfig', true);
 
       const editor = await atom.workspace.open(badFile);
       spyOn(editor, 'getPath').andReturn(__dirname);


### PR DESCRIPTION
As requested in #150, implements an option to disable linter-htmllint when no `.htmlhintrc` file is found 🎉 

Fixes #150.