### PR TITLE
docs: update link to HTMLHint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ This plugin will search for a [HTMLHint] configuration file called `.htmlhintrc`
 You can configure `linter-htmlhint` in Atom's Settings.
 
 [linter]: https://github.com/atom-community/linter "Linter"
-[HTMLHint]: https://github.com/yaniswang/HTMLHint "HTMLHint"
+[HTMLHint]: https://github.com/thedaviddias/HTMLHint "HTMLHint"

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ This plugin will search for a [HTMLHint] configuration file called `.htmlhintrc`
 You can configure `linter-htmlhint` in Atom's Settings.
 
 [linter]: https://github.com/atom-community/linter "Linter"
-[HTMLHint]: https://github.com/thedaviddias/HTMLHint "HTMLHint"
+[HTMLHint]: https://github.com/htmlhint/HTMLHint "HTMLHint"


### PR DESCRIPTION
The HTMLHint repository has moved owners and the correct link needs to be updated to reflect this.