### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ defaults: &defaults
         name: APM version
         command: ${APM_SCRIPT_PATH} --version
     - run:
-        name: Cleaning package
-        command: ${APM_SCRIPT_PATH} clean
-    - run:
         name: Package APM package dependencies
         command: |
           if [ -n "${APM_TEST_PACKAGES}" ]; then
@@ -32,13 +29,16 @@ defaults: &defaults
         name: Package dependencies
         command: ${APM_SCRIPT_PATH} install
     - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
+    - run:
         name: Package specs
         command: ${ATOM_SCRIPT_PATH} --test spec
     # Cache node_modules
     - save_cache:
         paths:
           - node_modules
-        key: v1-dependencies-{{ checksum "package.json" }}
+        key: v2-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
 
 jobs:
   checkout_code:
@@ -50,10 +50,15 @@ jobs:
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v1-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v1-dependencies
+          # Get latest cache for this package.json and package-lock.json
+          - v2-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v2-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v2-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v2-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp
@@ -62,7 +67,7 @@ jobs:
   lint:
     <<: *defaults
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:lts
     steps:
       # Restore project state
       - attach_workspace:


### PR DESCRIPTION
Only run `apm clean` _after_ `apm install`, to prevent issues with some dependencies (`husky`) that don't behave correctly.

Also updates the cache to be far more specific to prevent cross-branch "pollution" of bad caches.